### PR TITLE
Bugfix tokenize record

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 from fastapi import FastAPI, responses, status
-from typing import Tuple
 
 
 from controller import task_manager, tokenization_manager
@@ -27,7 +26,7 @@ def tokenize_record(request: Request) -> responses.PlainTextResponse:
 
 
 @app.post("/tokenize_calculated_attribute")
-def tokenize_record(
+def tokenize_calculated_attribute(
     request: AttributeTokenizationRequest,
 ) -> responses.PlainTextResponse:
     session_token = general.get_ctx_token()

--- a/controller/tokenization_manager.py
+++ b/controller/tokenization_manager.py
@@ -127,7 +127,7 @@ def tokenize_record(project_id: str, record_id: str) -> int:
         )
         tokenizer = get_tokenizer_by_project(project_id)
         record_item = record.get(project_id, record_id)
-        entry = tokenize_record(
+        entry = tokenize_single_record(
             project_id, tokenizer, record_item, text_attributes, update_statistic=True
         )
         general.add(entry)


### PR DESCRIPTION
change in tokenization_manager.py is the actual bugfix.
In the app.py, I removed an unused import and changed the name for an endpoint, so that the same name is not used twice.